### PR TITLE
Single Dockerfile, services for cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM python:3.10.11
+#FROM python:3.10.11
+#FROM wallies/python-cuda:3.10-cuda11.6-runtime
+
+# Using argument for base image to avoid multiplying Dockerfiles
+ARG BASEIMAGE
+FROM $BASEIMAGE
 
 RUN groupadd -g 10009 -o privategpt && useradd -m -u 10009 -g 10009 -o -s /bin/bash privategpt
 USER privategpt
 WORKDIR /home/privategpt
 
 COPY ./src/requirements.txt src/requirements.txt
-RUN pip install -r src/requirements.txt
+RUN pip install --no-cache-dir -r src/requirements.txt
 
 COPY ./src src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ USER privategpt
 WORKDIR /home/privategpt
 
 COPY ./src/requirements.txt src/requirements.txt
-RUN pip install --no-cache-dir -r src/requirements.txt
+ARG LLAMA_CMAKE
+#RUN CMAKE_ARGS="-DLLAMA_OPENBLAS=on" FORCE_CMAKE=1 pip install $(grep llama-cpp-python src/requirements.txt)
+RUN ( /bin/bash -c "${LLAMA_CMAKE} pip install \$(grep llama-cpp-python src/requirements.txt)" 2>&1 | tee llama-build.log ) && sleep 10
+RUN pip install --no-cache-dir -r src/requirements.txt 2>&1 | tee pip-install.log
 
 COPY ./src src
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,15 @@ services:
       args: [BASEIMAGE=wallies/python-cuda:3.10-cuda11.7-runtime]
 
   #
+  # For ingest without cuda:
+  # 
+  #  docker compose run --rm --build privategpt-ingest
+  #  
+  privategpt-ingest:
+    extends: privategpt
+    command: [python, src/ingest.py]
+
+  #
   # To ingest using cuda 11.6:
   # 
   #  docker compose run --rm --build privategpt-cuda-11.6-ingest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,12 +8,13 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-      args: [--rm, BASEIMAGE=python:3.10.11]
+      args: [--rm, BASEIMAGE=python:3.10.11, LLAMA_CMAMAKE:"" ]
     image: privategpt:test
     command: [python, src/privateGPT.py]
     environment:
       - PERSIST_DIRECTORY=${PERSIST_DIRECTORY:-/home/privategpt/db}
       - LLAMA_EMBEDDINGS_MODEL=${LLAMA_EMBEDDINGS_MODEL:-/home/privategpt/models/ggml-model-q4_0.bin}
+      - EMBEDDINGS_MODEL_NAME=${EMBEDDINGS_MODEL_NAME:-all-MiniLM-L6-v2}
       - MODEL_TYPE=${MODEL_TYPE:-GPT4All}
       - MODEL_PATH=${MODEL_PATH:-/home/privategpt/models/ggml-gpt4all-j-v1.3-groovy.bin}
       - MODEL_N_CTX=${MODEL_N_CTX:-1000}
@@ -29,7 +30,9 @@ services:
   privategpt-cuda-11.6:
     extends: privategpt
     build:
-      args: [BASEIMAGE=wallies/python-cuda:3.10-cuda11.6-runtime]
+      args:
+        - BASEIMAGE=wallies/python-cuda:3.10-cuda11.6-runtime
+        - LLAMA_CMAKE="-DLLAMA_OPENBLAS=on" FORCE_CMAKE=1"
     deploy:
       resources:
         reservations:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,16 @@
-version: "3.9"
+---
+version: '3.9'
 services:
+  #
+  # Base service, without CUDA
+  #
   privategpt:
-    build: .
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args: [--rm, BASEIMAGE=python:3.10.11]
     image: privategpt:test
-    command: [ "python", "src/privateGPT.py" ]
+    command: [python, src/privateGPT.py]
     environment:
       - PERSIST_DIRECTORY=${PERSIST_DIRECTORY:-/home/privategpt/db}
       - LLAMA_EMBEDDINGS_MODEL=${LLAMA_EMBEDDINGS_MODEL:-/home/privategpt/models/ggml-model-q4_0.bin}
@@ -13,3 +20,73 @@ services:
     volumes:
       - ${MODEL_MOUNT:-./models}:/home/privategpt/models
       - ${PERSIST_MOUNT:-./db}:/home/privategpt/db
+
+  #
+  # To run with CUDA 11.6
+  #
+  #  docker compose run --rm --build privategpt-cuda-11.6
+  # 
+  privategpt-cuda-11.6:
+    extends: privategpt
+    build:
+      args: [BASEIMAGE=wallies/python-cuda:3.10-cuda11.6-runtime]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+          memory: 8G
+
+  #
+  # To run with CUDA 11.7
+  #
+  #  docker compose run --rm --build privategpt-cuda-11.7
+  # 
+  privategpt-cuda-11.7:
+    extends: privategpt-cuda-11.6
+    build:
+      args: [BASEIMAGE=wallies/python-cuda:3.10-cuda11.7-runtime]
+
+  #
+  # To ingest using cuda 11.6:
+  # 
+  #  docker compose run --rm --build privategpt-cuda-11.6-ingest
+  #  
+  privategpt-cuda-11.6-ingest:
+    extends: privategpt-cuda-11.6
+    command: [python, src/ingest.py]
+
+  #
+  # To ingest using cuda 11.7:
+  # 
+  #  docker compose run --rm --build privategpt-cuda-11.7-ingest
+  #  
+  privategpt-cuda-11.7-ingest:
+    extends: privategpt-cuda-11.7
+    command: [python, src/ingest.py]
+
+  # Check your system's version using
+  # 
+  #  docker compose run --rm check-cuda-version
+  #
+  # then build and test the privateGPT container
+  # using
+  #
+  #  docker compose run --rm check-cuda-<CUDAVERSION>
+  #
+  # Where <CUDAVERSION> is the version you found using 'check-cuda-version'.
+  #
+  # Example if CUDAVERSION == 11.6
+  # 
+  #  docker compose run --rm --build check-cuda-11.6
+  check-cuda-version:
+    image: ubuntu
+    command: [nvidia-smi]
+  check-cuda-11.6:
+    extends: privategpt-cuda-11.6
+    command: [nvidia-smi]
+  check-cuda-11.7:
+    extends: privategpt-cuda-11.7
+    command: [nvidia-smi]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       - ${PERSIST_MOUNT:-./db}:/home/privategpt/db
       - ${SOURCE_MOUNT:-./source_documents}:/home/privategpt/source_documents
 
+
   #
   # To run with CUDA 11.6
   #
@@ -97,6 +98,15 @@ services:
   # Example if CUDAVERSION == 11.6
   #
   #  docker compose run --rm --build check-cuda-11.6
+  #
+  #
+  #
+  # You can update your host's CUDA installation by downloading
+  # a recent version from
+  #
+  # https://developer.nvidia.com/cuda-downloads .
+  #
+
   check-cuda-version:
     image: ubuntu
     command: [nvidia-smi]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-      args: [--rm, BASEIMAGE=python:3.10.11, LLAMA_CMAMAKE:"" ]
+      args: [--rm, "BASEIMAGE=python:3.10.11", LLAMA_CMAKE=]
     image: privategpt:test
     command: [python, src/privateGPT.py]
     environment:
@@ -20,19 +20,23 @@ services:
       - MODEL_N_CTX=${MODEL_N_CTX:-1000}
     volumes:
       - ${MODEL_MOUNT:-./models}:/home/privategpt/models
+      - type: bind
+        source: ${MODEL_MOUNT:-./models}/cache/torch
+        target: /home/privategpt/.cache/torch
       - ${PERSIST_MOUNT:-./db}:/home/privategpt/db
+      - ${SOURCE_MOUNT:-./source_documents}:/home/privategpt/source_documents
 
   #
   # To run with CUDA 11.6
   #
   #  docker compose run --rm --build privategpt-cuda-11.6
-  # 
+  #
   privategpt-cuda-11.6:
     extends: privategpt
     build:
       args:
         - BASEIMAGE=wallies/python-cuda:3.10-cuda11.6-runtime
-        - LLAMA_CMAKE="-DLLAMA_OPENBLAS=on" FORCE_CMAKE=1"
+        - LLAMA_CMAKE=CMAKE_ARGS='-DLLAMA_OPENBLAS=on' FORCE_CMAKE=1
     deploy:
       resources:
         reservations:
@@ -46,41 +50,41 @@ services:
   # To run with CUDA 11.7
   #
   #  docker compose run --rm --build privategpt-cuda-11.7
-  # 
+  #
   privategpt-cuda-11.7:
     extends: privategpt-cuda-11.6
     build:
-      args: [BASEIMAGE=wallies/python-cuda:3.10-cuda11.7-runtime]
+      args: ["BASEIMAGE=wallies/python-cuda:3.10-cuda11.7-runtime"]
 
   #
   # For ingest without cuda:
-  # 
+  #
   #  docker compose run --rm --build privategpt-ingest
-  #  
+  #
   privategpt-ingest:
     extends: privategpt
     command: [python, src/ingest.py]
 
   #
   # To ingest using cuda 11.6:
-  # 
+  #
   #  docker compose run --rm --build privategpt-cuda-11.6-ingest
-  #  
+  #
   privategpt-cuda-11.6-ingest:
     extends: privategpt-cuda-11.6
     command: [python, src/ingest.py]
 
   #
   # To ingest using cuda 11.7:
-  # 
+  #
   #  docker compose run --rm --build privategpt-cuda-11.7-ingest
-  #  
+  #
   privategpt-cuda-11.7-ingest:
     extends: privategpt-cuda-11.7
     command: [python, src/ingest.py]
 
   # Check your system's version using
-  # 
+  #
   #  docker compose run --rm check-cuda-version
   #
   # then build and test the privateGPT container
@@ -91,7 +95,7 @@ services:
   # Where <CUDAVERSION> is the version you found using 'check-cuda-version'.
   #
   # Example if CUDAVERSION == 11.6
-  # 
+  #
   #  docker compose run --rm --build check-cuda-11.6
   check-cuda-version:
     image: ubuntu


### PR DESCRIPTION
Making progress with CUDA, also added ingest into the main Dockerfile.

A docker-compose.yaml argument varies the base image according to the service.

I did not rename the file from yaml to yml.

Note: CUDA is not used yet in my local setup, but I no longer have the related error messages I had before.

Information I used:
- https://towardsdatascience.com/how-to-properly-use-the-gpu-within-a-docker-container-4c699c78c6d1
- https://docs.nvidia.com/cuda/wsl-user-guide/index.html
